### PR TITLE
qmi-framework: Unify API naming and error handling conventions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,10 +6,10 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 ACLOCAL_AMFLAGS = -I m4
 pkginclude_HEADERS = \
                 include/common_v01.h \
-                include/qcsi.h \
+                include/qmi_csi.h \
                 include/qcsi_target_ext.h \
                 include/qmi_cci_target_ext.h \
-                include/qmi_client.h \
+                include/qmi_cci.h \
                 include/qmi_idl_lib.h \
                 include/qmi_idl_lib_internal.h
 SUBDIRS = common qencdec qcci qcsi tests

--- a/include/qmi_cci.h
+++ b/include/qmi_cci.h
@@ -23,24 +23,25 @@
 extern "C" {
 #endif
 
-#define QMI_NO_ERR                0
-#define QMI_INTERNAL_ERR          (-1)
-#define QMI_SERVICE_ERR           (-2)
-#define QMI_TIMEOUT_ERR           (-3)
-#define QMI_EXTENDED_ERR          (-4)
-#define QMI_PORT_NOT_OPEN_ERR     (-5)
-#define QMI_MEMCOPY_ERROR         (-13)
-#define QMI_INVALID_TXN           (-14)
-#define QMI_CLIENT_ALLOC_FAILURE  (-15)
-#define QMI_CLIENT_TRANSPORT_ERR  (-16)
-#define QMI_CLIENT_PARAM_ERR      (-17)
-#define QMI_CLIENT_INVALID_CLNT   (-18)
-#define QMI_CLIENT_FW_NOT_UP      (-19)
-#define QMI_CLIENT_INVALID_SIG    (-20)
-#define QMI_XPORT_BUSY_ERR        (-21)
+typedef enum {
+    QMI_NO_ERR = 0,
+    QMI_INTERNAL_ERR = -1,
+    QMI_SERVICE_ERR = -2,
+    QMI_TIMEOUT_ERR = -3,
+    QMI_EXTENDED_ERR = -4,
+    QMI_PORT_NOT_OPEN_ERR = -5,
+    QMI_MEMCOPY_ERROR = -13,
+    QMI_INVALID_TXN = -14,
+    QMI_CLIENT_ALLOC_FAILURE = -15,
+    QMI_CLIENT_TRANSPORT_ERR = -16,
+    QMI_CLIENT_PARAM_ERR = -17,
+    QMI_CLIENT_INVALID_CLNT = -18,
+    QMI_CLIENT_FW_NOT_UP = -19,
+    QMI_CLIENT_INVALID_SIG = -20,
+    QMI_XPORT_BUSY_ERR = -21
+} qmi_cci_error_type;
 
 typedef struct         qmi_client_struct *qmi_client_type;
-typedef int            qmi_client_error_type;
 typedef void           *qmi_txn_handle;
 
 /** Magic instance ID for .. to indicate that no preference on instance ID */
@@ -102,7 +103,7 @@ typedef void (*qmi_client_log_cb)
 	unsigned int                   txn_id,
 	const void                     *raw_msg,
 	unsigned int                   raw_msg_len,
-	qmi_client_error_type          status,
+	qmi_cci_error_type          status,
 	void                           *cookie
 );
 
@@ -173,7 +174,7 @@ typedef void (*qmi_client_recv_raw_msg_async_cb)
 	void                           *resp_buf,
 	unsigned int                   resp_buf_len,
 	void                           *resp_cb_data,
-	qmi_client_error_type          transp_err
+	qmi_cci_error_type          transp_err
 );
 
 /*=============================================================================
@@ -202,7 +203,7 @@ typedef void (*qmi_client_recv_msg_async_cb)
 	void                           *resp_c_struct,
 	unsigned int                   resp_c_struct_len,
 	void                           *resp_cb_data,
-	qmi_client_error_type          transp_err
+	qmi_cci_error_type          transp_err
 );
 
 /*=============================================================================
@@ -249,12 +250,12 @@ typedef void (*qmi_client_ind_cb)
 typedef void (*qmi_client_error_cb)
 (
 	qmi_client_type user_handle,
-	qmi_client_error_type error,
+	qmi_cci_error_type error,
 	void *err_cb_data
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_notifier_init
+  FUNCTION  qmi_cci_notifier_init
 ===========================================================================*/
 /*!
 @brief
@@ -283,8 +284,8 @@ typedef void (*qmi_client_error_cb)
       registered
 */
 /*=========================================================================*/
-extern qmi_client_error_type
-qmi_client_notifier_init
+extern qmi_cci_error_type
+qmi_cci_notifier_init
 (
 	qmi_idl_service_object_type               service_obj,
 	qmi_client_os_params                      *os_params,
@@ -292,7 +293,7 @@ qmi_client_notifier_init
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_init
+  FUNCTION  qmi_cci_init
 ===========================================================================*/
 /*!
 @brief
@@ -322,8 +323,8 @@ qmi_client_notifier_init
     - QMI connection is opened with the service
 */
 /*=========================================================================*/
-extern  qmi_client_error_type
-qmi_client_init
+extern  qmi_cci_error_type
+qmi_cci_init
 (
 	qmi_service_info                          *service_info,
 	qmi_idl_service_object_type               service_obj,
@@ -336,7 +337,7 @@ qmi_client_init
 
 
 /*===========================================================================
-  FUNCTION  qmi_client_send_raw_msg_async
+  FUNCTION  qmi_cci_send_raw_msg_async
 ===========================================================================*/
 /*!
 @brief
@@ -366,8 +367,8 @@ qmi_client_init
   - Side Effects
 */
 /*=========================================================================*/
-extern qmi_client_error_type
-qmi_client_send_raw_msg_async
+extern qmi_cci_error_type
+qmi_cci_send_raw_msg_async
 (
 	qmi_client_type                   user_handle,
 	unsigned int                      msg_id,
@@ -382,7 +383,7 @@ qmi_client_send_raw_msg_async
 
 
 /*===========================================================================
-  FUNCTION  qmi_client_send_msg_async
+  FUNCTION  qmi_cci_send_msg_async
 ===========================================================================*/
 /*!
 @brief
@@ -415,8 +416,8 @@ qmi_client_send_raw_msg_async
 */
 /*=========================================================================*/
 
-qmi_client_error_type
-qmi_client_send_msg_async
+qmi_cci_error_type
+qmi_cci_send_msg_async
 (
 	qmi_client_type                 user_handle,
 	unsigned int                    msg_id,
@@ -431,7 +432,7 @@ qmi_client_send_msg_async
 
 
 /*===========================================================================
-  FUNCTION  qmi_client_delete_async_txn
+  FUNCTION  qmi_cci_delete_async_txn
 ===========================================================================*/
 /*!
 @brief
@@ -456,8 +457,8 @@ qmi_client_send_msg_async
   by the "users_rsp_cb" callback up until this routine returns.
 */
 /*=========================================================================*/
-extern qmi_client_error_type
-qmi_client_delete_async_txn
+extern qmi_cci_error_type
+qmi_cci_delete_async_txn
 (
 	qmi_client_type  user_handle,
 	qmi_txn_handle   async_txn_handle
@@ -465,7 +466,7 @@ qmi_client_delete_async_txn
 
 
 /*===========================================================================
-  FUNCTION  qmi_client_send_raw_msg_sync
+  FUNCTION  qmi_cci_send_raw_msg_sync
 ===========================================================================*/
 /*!
 @brief
@@ -495,8 +496,8 @@ qmi_client_delete_async_txn
     - None
 */
 /*=========================================================================*/
-extern qmi_client_error_type
-qmi_client_send_raw_msg_sync
+extern qmi_cci_error_type
+qmi_cci_send_raw_msg_sync
 (
 	qmi_client_type           user_handle,
 	unsigned int              msg_id,
@@ -510,7 +511,7 @@ qmi_client_send_raw_msg_sync
 
 
 /*===========================================================================
-  FUNCTION  qmi_client_send_msg_sync
+  FUNCTION  qmi_cci_send_msg_sync
 ===========================================================================*/
 /*!
 @brief
@@ -539,8 +540,8 @@ qmi_client_send_raw_msg_sync
     - None
 */
 /*=========================================================================*/
-extern qmi_client_error_type
-qmi_client_send_msg_sync
+extern qmi_cci_error_type
+qmi_cci_send_msg_sync
 (
 	qmi_client_type    user_handle,
 	unsigned int       msg_id,
@@ -552,7 +553,7 @@ qmi_client_send_msg_sync
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_release_async
+  FUNCTION  qmi_cci_release_async
 ===========================================================================*/
 /*!
 @brief
@@ -577,8 +578,8 @@ qmi_client_send_msg_sync
    - None
 */
 /*=========================================================================*/
-extern qmi_client_error_type
-qmi_client_release_async
+extern qmi_cci_error_type
+qmi_cci_release_async
 (
 	qmi_client_type       user_handle,
 	qmi_client_release_cb release_cb,
@@ -586,7 +587,7 @@ qmi_client_release_async
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_release
+  FUNCTION  qmi_cci_release
 ===========================================================================*/
 /*!
 @brief
@@ -606,8 +607,8 @@ qmi_client_release_async
    - None
 */
 /*=========================================================================*/
-extern qmi_client_error_type
-qmi_client_release
+extern qmi_cci_error_type
+qmi_cci_release
 (
 	qmi_client_type     user_handle
 );
@@ -615,7 +616,7 @@ qmi_client_release
 
 
 /*===========================================================================
-  FUNCTION  qmi_client_message_encode
+  FUNCTION  qmi_cci_message_encode
 ===========================================================================*/
 /*!
 @brief
@@ -636,8 +637,8 @@ qmi_client_release
 @retval    QMI_NO_ERR     Success
 @retval    QMI_IDL_...    Error, see error codes defined in qmi.h*/
 /*=========================================================================*/
-extern qmi_client_error_type
-qmi_client_message_encode
+extern qmi_cci_error_type
+qmi_cci_message_encode
 (
 	qmi_client_type                      user_handle,
 	qmi_idl_type_of_message_type         req_resp_ind,
@@ -650,7 +651,7 @@ qmi_client_message_encode
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_message_decode
+  FUNCTION  qmi_cci_message_decode
 ===========================================================================*/
 /*!
 @brief
@@ -670,8 +671,8 @@ qmi_client_message_encode
 @retval    QMI_IDL_...    Error, see error codes defined in qmi.h
 */
 /*=========================================================================*/
-extern qmi_client_error_type
-qmi_client_message_decode
+extern qmi_cci_error_type
+qmi_cci_message_decode
 (
 	qmi_client_type                         user_handle,
 	qmi_idl_type_of_message_type            req_resp_ind,
@@ -683,7 +684,7 @@ qmi_client_message_decode
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_get_service_list
+  FUNCTION  qmi_cci_get_service_list
 ===========================================================================*/
 /*!
 @brief
@@ -708,8 +709,8 @@ qmi_client_message_decode
 */
 /*=========================================================================*/
 
-qmi_client_error_type
-qmi_client_get_service_list
+qmi_cci_error_type
+qmi_cci_get_service_list
 (
 	qmi_idl_service_object_type   service_obj,
 	qmi_service_info       *service_info_array,
@@ -718,7 +719,7 @@ qmi_client_get_service_list
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_get_any_service
+  FUNCTION  qmi_cci_get_any_service
 ===========================================================================*/
 /*!
 @brief
@@ -739,15 +740,15 @@ qmi_client_get_service_list
    - service_info may be written
 */
 /*=========================================================================*/
-qmi_client_error_type
-qmi_client_get_any_service
+qmi_cci_error_type
+qmi_cci_get_any_service
 (
 	qmi_idl_service_object_type service_obj,
 	qmi_service_info *service_info
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_get_service_instance
+  FUNCTION  qmi_cci_get_service_instance
 ===========================================================================*/
 /*!
 @brief
@@ -770,8 +771,8 @@ qmi_client_get_any_service
    - service_info may be written
 */
 /*=========================================================================*/
-qmi_client_error_type
-qmi_client_get_service_instance
+qmi_cci_error_type
+qmi_cci_get_service_instance
 (
 	qmi_idl_service_object_type service_obj,
 	qmi_service_instance instance_id,
@@ -779,7 +780,7 @@ qmi_client_get_service_instance
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_get_instance_id
+  FUNCTION  qmi_cci_get_instance_id
 ===========================================================================*/
 /*!
 @brief
@@ -794,15 +795,15 @@ qmi_client_get_service_instance
   error code if not successful
 */
 /*=========================================================================*/
-qmi_client_error_type
-qmi_client_get_instance_id
+qmi_cci_error_type
+qmi_cci_get_instance_id
 (
 	qmi_service_info *service_info,
 	qmi_service_instance *instance_id
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_register_error_cb
+  FUNCTION  qmi_cci_register_error_cb
 ===========================================================================*/
 /*!
 @brief
@@ -819,7 +820,7 @@ qmi_client_get_instance_id
          QMI_INTERNAL_ERR Invalid input parameters
 */
 /*=========================================================================*/
-qmi_client_error_type qmi_client_register_error_cb
+qmi_cci_error_type qmi_cci_register_error_cb
 (
 	qmi_client_type user_handle,
 	qmi_client_error_cb err_cb,
@@ -827,7 +828,7 @@ qmi_client_error_type qmi_client_register_error_cb
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_register_notify_cb
+  FUNCTION  qmi_cci_register_notify_cb
 ===========================================================================*/
 /*!
 @brief
@@ -844,7 +845,7 @@ qmi_client_error_type qmi_client_register_error_cb
          QMI_INTERNAL_ERR Invalid input parameters
 */
 /*=========================================================================*/
-qmi_client_error_type qmi_client_register_notify_cb
+qmi_cci_error_type qmi_cci_register_notify_cb
 (
 	qmi_client_type user_handle,
 	qmi_client_notify_cb notify_cb,
@@ -852,7 +853,7 @@ qmi_client_error_type qmi_client_register_notify_cb
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_register_log_cb
+  FUNCTION  qmi_cci_register_log_cb
 ===========================================================================*/
 /*!
 @brief
@@ -869,7 +870,7 @@ qmi_client_error_type qmi_client_register_notify_cb
          QMI_INTERNAL_ERR Invalid input parameters
 */
 /*=========================================================================*/
-qmi_client_error_type qmi_client_register_log_cb
+qmi_cci_error_type qmi_cci_register_log_cb
 (
 	qmi_client_type user_handle,
 	qmi_client_log_cb notify_cb,
@@ -877,7 +878,7 @@ qmi_client_error_type qmi_client_register_log_cb
 );
 
 /*===========================================================================
-  FUNCTION  qmi_client_init_instance
+  FUNCTION  qmi_cci_init_instance
 ===========================================================================*/
 /*!
 @brief
@@ -916,7 +917,7 @@ qmi_client_error_type qmi_client_register_log_cb
 
 */
 /*=========================================================================*/
-qmi_client_error_type qmi_client_init_instance
+qmi_cci_error_type qmi_cci_init_instance
 (
 	qmi_idl_service_object_type service_obj,
 	qmi_service_instance        instance_id,

--- a/include/qmi_csi.h
+++ b/include/qmi_csi.h
@@ -29,7 +29,7 @@ typedef enum {
 	QCSI_DECODE_ERR,
 	QCSI_NO_MEM,
 	QCSI_INTERNAL_ERR
-} qcsi_error;
+} qmi_csi_error_type;
 
 typedef enum {
 	QCSI_CB_NO_ERR = 0,
@@ -213,13 +213,13 @@ typedef struct qcsi_options_struct qcsi_options;
                                  identify different services.
 @param[in]   service_cookie      Service specific data. Service cookie is
                                  registered with the infrastructure during
-                                 service registration(qcsi_register).
+                                 service registration(qmi_csi_register).
 @param[out]  connection_handle   Services return this handle as a token to
                                  represent this client connection
                                  to the service.
 
 @retval    QCSI_CB_NO_ERR     Success
-@retval    QCSI_CB.....       Look into the enumeration qcsi_error for
+@retval    QCSI_CB.....       Look into the enumeration qmi_csi_error_type for
                                  the error values.
 */
 /*=========================================================================*/
@@ -243,9 +243,9 @@ typedef qcsi_cb_error (*qcsi_connect)
                                    disconnecting.
 @param[in]  service_cookie         Service specific data.Service cookie is
                                    registered with the infrastructure during
-                                   service registration(qcsi_register).
+                                   service registration(qmi_csi_register).
 @retval    QCSI_CB_NO_ERR       Success
-@retval    QCSI_CB.....         Look into the enumeration qcsi_error for
+@retval    QCSI_CB.....         Look into the enumeration qmi_csi_error_type for
                                    the error values.
 */
 /*=========================================================================*/
@@ -275,11 +275,11 @@ typedef void (*qcsi_disconnect)
 @param[in]  req_c_struct_len       Length of the c struct.
 @param[in]  service_cookie         Service specific data.Service cookie is
                                    registered with the infrastructure during
-                                   service registration(qcsi_register).
+                                   service registration(qmi_csi_register).
 
 
 @retval    QCSI_CB_NO_ERR       Success
-@retval    QCSI_CB.....         Look into the enumeration qcsi_error for
+@retval    QCSI_CB.....         Look into the enumeration qmi_csi_error_type for
                                    the error values.
 */
 /*=========================================================================*/
@@ -308,7 +308,7 @@ typedef qcsi_cb_error (*qcsi_process_req)
                                  qcsi_connect.
 @param[in]   service_cookie      Service specific data. Service cookie is
                                  registered with the infrastructure during
-                                 service registration(qcsi_register).
+                                 service registration(qmi_csi_register).
                                  represent this client connection
                                  to the service.
 
@@ -358,7 +358,7 @@ typedef void (*qcsi_log_msg)
 
 
 /*=============================================================================
-  FUNCTION  qcsi_register
+  FUNCTION  qmi_csi_register
 =============================================================================*/
 /*!
 @brief
@@ -375,13 +375,13 @@ typedef void (*qcsi_log_msg)
 @param[out] service_provider    Handle that infra provides to represent this
                                 service connection.
 @retval    QCSI_NO_ERR       Success
-@retval    qcsi_.....        Look into the enumeration qcsi_error for
+@retval    qcsi_.....        Look into the enumeration qmi_csi_error_type for
                                 the error values.
 */
 /*=========================================================================*/
 
-qcsi_error
-qcsi_register
+qmi_csi_error_type
+qmi_csi_register
 (
 	qmi_idl_service_object_type               service_obj,
 	qcsi_connect                           service_connect,
@@ -394,7 +394,7 @@ qcsi_register
 
 
 /*=============================================================================
-  FUNCTION  qcsi_register_with_options
+  FUNCTION  qmi_csi_register_with_options
 =============================================================================*/
 /*!
 @brief
@@ -412,13 +412,13 @@ qcsi_register
 @param[out] service_provider    Handle that infra provides to represent this
                                 service connection.
 @retval    QCSI_NO_ERR       Success
-@retval    QCSI_.....        Look into the enumeration qcsi_error for
+@retval    QCSI_.....        Look into the enumeration qmi_csi_error_type for
                                 the error values.
 */
 /*=========================================================================*/
 
-qcsi_error
-qcsi_register_with_options
+qmi_csi_error_type
+qmi_csi_register_with_options
 (
 	qmi_idl_service_object_type               service_obj,
 	qcsi_connect                           service_connect,
@@ -436,7 +436,7 @@ qcsi_register_with_options
 /*!
 @brief
   Handle event after the server thread receives an event notification.
-  Callbacks from qcsi_register may be invoked in the server's context.
+  Callbacks from qmi_csi_register may be invoked in the server's context.
 
 @param[in] service_provider    Opaque handle that defines the service.
 @param[in] os_params           OS-defined parameters such as file handle.
@@ -446,15 +446,15 @@ qcsi_register_with_options
 */
 /*=========================================================================*/
 
-qcsi_error
-qcsi_handle_event
+qmi_csi_error_type
+qmi_csi_handle_event
 (
 	qcsi_service_handle                    service_provider,
 	qcsi_os_params                         *os_params
 );
 
 /*=============================================================================
-  FUNCTION  qcsi_send_resp
+  FUNCTION  qmi_csi_send_resp
 =============================================================================*/
 /*!
 @brief
@@ -468,12 +468,12 @@ qcsi_handle_event
 @param[in]  resp_c_struct_len     Size of the response c struct.
 
 @retval  QCSI_NO_ERR           Success.
-@retval  qcsi_.....            Look into the enumeration qcsi_error for
+@retval  qcsi_.....            Look into the enumeration qmi_csi_error_type for
                                   the error values.
 */
 /*=========================================================================*/
-qcsi_error
-qcsi_send_resp
+qmi_csi_error_type
+qmi_csi_send_resp
 (
 	qmi_req_handle     req_handle,
 	unsigned int       msg_id,
@@ -482,7 +482,7 @@ qcsi_send_resp
 );
 
 /*=============================================================================
-  FUNCTION  qcsi_send_resp_raw
+  FUNCTION  qmi_csi_send_resp_raw
 =============================================================================*/
 /*!
 @brief
@@ -496,12 +496,12 @@ qcsi_send_resp
 @param[in]  resp_buf_len          Size of the response buffer
 
 @retval  QCSI_NO_ERR           Success.
-@retval  QCSI_.....            Look into the enumeration qcsi_error for
+@retval  QCSI_.....            Look into the enumeration qmi_csi_error_type for
                                   the error values.
 */
 /*=========================================================================*/
-qcsi_error
-qcsi_send_resp_raw
+qmi_csi_error_type
+qmi_csi_send_resp_raw
 (
 	qmi_req_handle     req_handle,
 	unsigned int       msg_id,
@@ -510,7 +510,7 @@ qcsi_send_resp_raw
 );
 
 /*=============================================================================
-  FUNCTION  qcsi_send_ind
+  FUNCTION  qmi_csi_send_ind
 =============================================================================*/
 /*!
 @brief
@@ -523,12 +523,12 @@ qcsi_send_resp_raw
 @param[in]  ind_c_struct_len         Size of the indication c struct
 
 @retval    QCSI_NO_ERR            Success.
-@retval    QCSI_.....             Look into the enumeration qcsi_error for
+@retval    QCSI_.....             Look into the enumeration qmi_csi_error_type for
                                      the error values.
 */
 /*=========================================================================*/
-qcsi_error
-qcsi_send_ind
+qmi_csi_error_type
+qmi_csi_send_ind
 (
 	qmi_client_handle  client_handle,
 	unsigned int       msg_id,
@@ -537,7 +537,7 @@ qcsi_send_ind
 );
 
 /*=============================================================================
-  FUNCTION  qcsi_send_ind_raw
+  FUNCTION  qmi_csi_send_ind_raw
 =============================================================================*/
 /*!
 @brief
@@ -550,12 +550,12 @@ qcsi_send_ind
 @param[in]  ind_buf_len              Size of the indication buffer.
 
 @retval    QCSI_NO_ERR            Success.
-@retval    QCSI_.....             Look into the enumeration qcsi_error for
+@retval    QCSI_.....             Look into the enumeration qmi_csi_error_type for
                                      the error values.
 */
 /*=========================================================================*/
-qcsi_error
-qcsi_send_ind_raw
+qmi_csi_error_type
+qmi_csi_send_ind_raw
 (
 	qmi_client_handle  client_handle,
 	unsigned int       msg_id,
@@ -564,7 +564,7 @@ qcsi_send_ind_raw
 );
 
 /*=============================================================================
-  FUNCTION  qcsi_send_broadcast_ind
+  FUNCTION  qmi_csi_send_broadcast_ind
 =============================================================================*/
 /*!
 @brief
@@ -579,13 +579,13 @@ qcsi_send_ind_raw
 @param[in]  ind_c_struct_len         Size of the broadcast indication
 
 @retval    QCSI_NO_ERR            Success
-@retval    QCSI_.....             Look into the enumeration qcsi_error for
+@retval    QCSI_.....             Look into the enumeration qmi_csi_error_type for
                                      the error values.
 */
 /*=========================================================================*/
 
-qcsi_error
-qcsi_send_broadcast_ind
+qmi_csi_error_type
+qmi_csi_send_broadcast_ind
 (
 	qcsi_service_handle   service_provider,
 	unsigned int             msg_id,
@@ -608,13 +608,13 @@ qcsi_send_broadcast_ind
 @param[in]  ind_buf_len              Size of the broadcast indication
 
 @retval    qcsi_NO_ERR            Success
-@retval    QCSI_.....             Look into the enumeration qcsi_error for
+@retval    QCSI_.....             Look into the enumeration qmi_csi_error_type for
                                      the error values.
 */
 /*=========================================================================*/
 
-qcsi_error
-qcsi_send_broadcast_ind_raw
+qmi_csi_error_type
+qmi_csi_send_broadcast_ind_raw
 (
 	qcsi_service_handle   service_provider,
 	unsigned int             msg_id,
@@ -629,15 +629,15 @@ qcsi_send_broadcast_ind_raw
 @brief
   Unregisters a server.
 
-@param[in]  service_provider         Handle given in the qcsi_register by
+@param[in]  service_provider         Handle given in the qmi_csi_register by
                                      the service.
 @retval     QCSI_NO_ERR           Success
-@retval     QCSI_.....            Look into the enumeration qcsi_error for
+@retval     QCSI_.....            Look into the enumeration qmi_csi_error_type for
                                      the error values.
 */
 /*=========================================================================*/
-qcsi_error
-qcsi_unregister
+qmi_csi_error_type
+qmi_csi_unregister
 (
 	qcsi_service_handle service_provider
 );

--- a/qcci/Makefile.am
+++ b/qcci/Makefile.am
@@ -38,7 +38,7 @@ endif
 library_includedir = $(pkgincludedir)
 noinst_HEADERS = $(h_sources)
 
-c_sources = qcci.c \
+c_sources = qcci_common.c \
         qcci_os.c \
         qcci_xport_qrtr.c
 

--- a/qcci/qcci_common.h
+++ b/qcci/qcci_common.h
@@ -179,7 +179,7 @@ typedef void *(*qcci_open_fn_type)
  *
  * @retval QMI_NO_ERR Success
  */
-typedef qmi_client_error_type (*qcci_send_fn_type)
+typedef qmi_cci_error_type (*qcci_send_fn_type)
 (
 	void *handle,
 	void *addr,
@@ -319,7 +319,7 @@ void qcci_xport_resume
  *
  * @retval QMI_CSI_NO_ERR Success
  */
-qmi_client_error_type qcci_xport_recv
+qmi_cci_error_type qcci_xport_recv
 (
 	qcci_client_type *clnt,
 	void *addr,
@@ -401,7 +401,7 @@ void qcci_xport_event_server_error
  * @note This function is NOT re-enterable or thread safe. The only safe place
  * to call this is during initialization.
  */
-qmi_client_error_type qcci_init(
+qmi_cci_error_type qcci_init(
 	qcci_xport_ops_type	*xport_ops,
 	void			*xport_data);
 
@@ -415,6 +415,6 @@ qmi_client_error_type qcci_init(
  * @note This function is NOT re-enterable or thread safe. The only safe place
  *       to call this is during library de-initialization.
  */
-qmi_client_error_type qcci_deinit(void);
+qmi_cci_error_type qcci_deinit(void);
 
 #endif

--- a/qcci/qcci_os.c
+++ b/qcci/qcci_os.c
@@ -7,9 +7,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdbool.h>
-#include "qmi_client.h"
+#include "qmi_cci.h"
 #include "qcci_os.h"
-#include "qcci_internal.h"
+#include "qcci_common.h"
 #include "config.h"
 
 #ifdef QMI_FW_SYSLOG

--- a/qcci/qcci_xport_qrtr.c
+++ b/qcci/qcci_xport_qrtr.c
@@ -16,9 +16,9 @@
 #include <poll.h>
 #include <fcntl.h>
 #include <linux/qrtr.h>
-#include "qmi_client.h"
+#include "qmi_cci.h"
 #include "qcci_os.h"
-#include "qcci_internal.h"
+#include "qcci_common.h"
 
 #define ALIGN_SIZE(x) ((4 - ((x) & 3)) & 3)
 
@@ -658,7 +658,7 @@ xport_open_free_xp:
  *
  * @return	QMI_NO_ERR on success, error code otherwise.
  */
-static qmi_client_error_type xport_send
+static qmi_cci_error_type xport_send
 (
 	void *handle,
 	void *addr,

--- a/qcsi/qcsi_common.c
+++ b/qcsi/qcsi_common.c
@@ -10,7 +10,7 @@
  */
 #include <string.h>
 #include "qmi_idl_lib.h"
-#include "qcsi.h"
+#include "qmi_csi.h"
 #include "qcsi_os.h"
 #include "qcsi_common.h"
 #include "common_v01.h"
@@ -419,7 +419,7 @@ static qcsi_client_type *create_client
  * @retval QCSI_ENCODE_ERR Encoding error.
  * @retval QCSI_TRANSPORT_ERR Transport error.
  */
-static qcsi_error internal_send
+static qmi_csi_error_type internal_send
 (
 	qcsi_service_type *svc,
 	qcsi_client_type *clnt,
@@ -433,7 +433,7 @@ static qcsi_error internal_send
 {
 	qcsi_xport_type *xport;
 	uint32_t max_msg_len = 0, out_len;
-	qcsi_error rc;
+	qmi_csi_error_type rc;
 	int32_t encdec_rc;
 	unsigned char *msg;
 	uint8_t cntl_flag;
@@ -558,7 +558,7 @@ static qcsi_error internal_send
  * @retval QCSI_NO_MEM No memory.
  * @retval QCSI_ENCODE_ERR Encoding error.
  */
-static qcsi_error encode_and_send_resp
+static qmi_csi_error_type encode_and_send_resp
 (
 	qcsi_xport_type *xport,
 	void *addr,
@@ -569,7 +569,7 @@ static qcsi_error encode_and_send_resp
 )
 {
 	uint32_t resp_msg_len;
-	qcsi_error rc;
+	qmi_csi_error_type rc;
 	unsigned char *msg;
 
 	resp_msg_len = qmi_idl_get_std_resp_tlv_len();
@@ -616,7 +616,7 @@ static qcsi_error encode_and_send_resp
  * @retval QCSI_CONN_REFUSED Connection refused.
  * @retval QCSI_INTERNAL_ERR Internal error.
  */
-qcsi_error qcsi_xport_connect
+qmi_csi_error_type qcsi_xport_connect
 (
 	qcsi_xport_type *xport,
 	void *addr
@@ -628,7 +628,7 @@ qcsi_error qcsi_xport_connect
 	uint32_t client_handle = 0xffffffff;
 	void *service_cookie = NULL;
 	void *connection_handle = NULL;
-	qcsi_error rc = QCSI_INTERNAL_ERR;
+	qmi_csi_error_type rc = QCSI_INTERNAL_ERR;
 	qcsi_cb_error cb_rc;
 
 	if(!xport || !xport->service || !addr)
@@ -703,7 +703,7 @@ qcsi_error qcsi_xport_connect
  * @retval QCSI_NO_ERR Success.
  * @retval QMI_ERR_INTERNAL_V01 Internal error.
  */
-qcsi_error qcsi_xport_recv
+qmi_csi_error_type qcsi_xport_recv
 (
 	qcsi_xport_type *xport,
 	void *addr,
@@ -942,7 +942,7 @@ void qcsi_xport_resume_client
  * @retval QCSI_NO_ERR Success.
  * @retval QCSI_INTERNAL_ERR Internal error.
  */
-qcsi_error qcsi_xport_disconnect
+qmi_csi_error_type qcsi_xport_disconnect
 (
 	qcsi_xport_type *xport,
 	void *addr
@@ -1037,8 +1037,8 @@ void qcsi_xport_closed
  * @retval QCSI_INTERNAL_ERR Internal error.
  * @retval QCSI_NO_MEM No memory.
  */
-qcsi_error
-qcsi_register_with_options
+qmi_csi_error_type
+qmi_csi_register_with_options
 (
 	qmi_idl_service_object_type               service_obj,
 	qcsi_connect                           service_connect,
@@ -1193,7 +1193,7 @@ qcsi_register_with_options
  * @retval QCSI_NO_ERR Success.
  * @retval QCSI_INTERNAL_ERR Internal error.
  */
-qcsi_error qcsi_register (
+qmi_csi_error_type qmi_csi_register (
 	qmi_idl_service_object_type               service_obj,
 	qcsi_connect                           service_connect,
 	qcsi_disconnect                        service_disconnect,
@@ -1202,7 +1202,7 @@ qcsi_error qcsi_register (
 	qcsi_os_params                         *os_params,
 	qcsi_service_handle                    *service_provider)
 {
-	return qcsi_register_with_options(
+	return qmi_csi_register_with_options(
 		       service_obj,
 		       service_connect,
 		       service_disconnect,
@@ -1224,7 +1224,7 @@ qcsi_error qcsi_register (
  * @retval QCSI_NO_ERR Success.
  * @retval QCSI_INVALID_HANDLE Invalid handle.
  */
-qcsi_error qcsi_handle_event(
+qmi_csi_error_type qmi_csi_handle_event(
     qcsi_service_handle service_provider,
     qcsi_os_params *os_params)
 {
@@ -1265,7 +1265,7 @@ qcsi_error qcsi_handle_event(
  * @retval QCSI_INVALID_ARGS Invalid arguments.
  * @retval QCSI_INVALID_HANDLE Invalid handle.
  */
-qcsi_error qcsi_send_resp_internal(
+qmi_csi_error_type qcsi_send_resp_internal(
     qmi_req_handle req_handle,
     unsigned int msg_id,
     void *c_struct,
@@ -1274,7 +1274,7 @@ qcsi_error qcsi_send_resp_internal(
 {
 	qcsi_txn_type *txn;
 	qcsi_client_type *clnt;
-	qcsi_error rc;
+	qmi_csi_error_type rc;
 
 	if(c_struct_len <= 0)
 		return QCSI_INVALID_ARGS;
@@ -1325,7 +1325,7 @@ send_resp_bail:
  * @retval QCSI_INVALID_ARGS Invalid arguments.
  * @retval QCSI_INVALID_HANDLE Invalid handle.
  */
-qcsi_error qcsi_send_resp(
+qmi_csi_error_type qmi_csi_send_resp(
     qmi_req_handle req_handle,
     unsigned int msg_id,
     void *c_struct,
@@ -1349,7 +1349,7 @@ qcsi_error qcsi_send_resp(
  * @retval QCSI_INVALID_ARGS Invalid arguments.
  * @retval QCSI_INVALID_HANDLE Invalid handle.
  */
-qcsi_error qcsi_send_resp_raw(
+qmi_csi_error_type qmi_csi_send_resp_raw(
     qmi_req_handle req_handle,
     unsigned int msg_id,
     void *c_struct,
@@ -1369,9 +1369,9 @@ qcsi_error qcsi_send_resp_raw(
  * @param c_struct_len Length of the structure.
  * @param encode Flag indicating whether to encode the message.
  *
- * @return qcsi_error Error code indicating the result of the operation.
+ * @return qmi_csi_error_type Error code indicating the result of the operation.
  */
-qcsi_error
+qmi_csi_error_type
 qcsi_send_ind_internal
 (
 	qmi_client_handle  client_handle,
@@ -1382,7 +1382,7 @@ qcsi_send_ind_internal
 )
 {
 	qcsi_client_type *clnt;
-	qcsi_error rc;
+	qmi_csi_error_type rc;
 
 	LOCK(&client_list_lock);
 	clnt = find_client((uint32_t)(uintptr_t)client_handle);
@@ -1419,10 +1419,10 @@ send_ind_bail:
  * @param c_struct Pointer to the structure containing the message data.
  * @param c_struct_len Length of the structure.
  *
- * @return qcsi_error Error code indicating the result of the operation.
+ * @return qmi_csi_error_type Error code indicating the result of the operation.
  */
-qcsi_error
-qcsi_send_ind
+qmi_csi_error_type
+qmi_csi_send_ind
 (
 	qmi_client_handle  client_handle,
 	unsigned int             msg_id,
@@ -1444,10 +1444,10 @@ qcsi_send_ind
  * @param buf Pointer to the buffer containing the message data.
  * @param buf_len Length of the buffer.
  *
- * @return qcsi_error Error code indicating the result of the operation.
+ * @return qmi_csi_error_type Error code indicating the result of the operation.
  */
-qcsi_error
-qcsi_send_ind_raw
+qmi_csi_error_type
+qmi_csi_send_ind_raw
 (
 	qmi_client_handle  client_handle,
 	unsigned int       msg_id,
@@ -1469,9 +1469,9 @@ qcsi_send_ind_raw
  * @param c_struct_len Length of the structure.
  * @param encode Flag indicating whether to encode the message.
  *
- * @return qcsi_error Error code indicating the result of the operation.
+ * @return qmi_csi_error_type Error code indicating the result of the operation.
  */
-qcsi_error
+qmi_csi_error_type
 qcsi_send_broadcast_ind_internal
 (
 	qcsi_service_handle   service_provider,
@@ -1482,7 +1482,7 @@ qcsi_send_broadcast_ind_internal
 )
 {
 	qcsi_service_type *svc;
-	qcsi_error rc;
+	qmi_csi_error_type rc;
 
 	/* lock client list first so if we find the service, the client list is
 	 * not going to be changed
@@ -1516,10 +1516,10 @@ broadcast_ind_bail:
  * @param c_struct Pointer to the structure containing the message data.
  * @param c_struct_len Length of the structure.
  *
- * @return qcsi_error Error code indicating the result of the operation.
+ * @return qmi_csi_error_type Error code indicating the result of the operation.
  */
-qcsi_error
-qcsi_send_broadcast_ind
+qmi_csi_error_type
+qmi_csi_send_broadcast_ind
 (
 	qcsi_service_handle   service_provider,
 	unsigned int             msg_id,
@@ -1541,10 +1541,10 @@ qcsi_send_broadcast_ind
  * @param buf Pointer to the buffer containing the message data.
  * @param buf_len Length of the buffer.
  *
- * @return qcsi_error Error code indicating the result of the operation.
+ * @return qmi_csi_error_type Error code indicating the result of the operation.
  */
-qcsi_error
-qcsi_send_broadcast_ind_raw
+qmi_csi_error_type
+qmi_csi_send_broadcast_ind_raw
 (
 	qcsi_service_handle   service_provider,
 	unsigned int             msg_id,
@@ -1564,10 +1564,10 @@ qcsi_send_broadcast_ind_raw
  *
  * @param service_provider Handle to the service provider.
  *
- * @return qcsi_error Error code indicating the result of the operation.
+ * @return qmi_csi_error_type Error code indicating the result of the operation.
  */
-qcsi_error
-qcsi_unregister
+qmi_csi_error_type
+qmi_csi_unregister
 (
 	qcsi_service_handle     service_provider
 )
@@ -1612,12 +1612,12 @@ qcsi_unregister
  * @note This function is NOT re-enterable or thread safe. The only safe place
  *       to call this is during initialization.
  */
-qcsi_error qcsi_init(
+qmi_csi_error_type qcsi_init(
 	qcsi_xport_ops_type	*xport_ops,
 	void			*xport_data)
 {
 	if (!xport_ops) {
-		return QCSI_INVALID_HANDLE;  //TODO: err code
+		return QCSI_INVALID_HANDLE;
 	}
 
 	if (qcsi_fw_inited == 0) {
@@ -1645,7 +1645,7 @@ qcsi_error qcsi_init(
  * @note This function is NOT re-enterable or thread safe. The only safe place
  *       to call this is during library de-initialization.
  */
-qcsi_error qcsi_deinit(void)
+qmi_csi_error_type qcsi_deinit(void)
 {
 	if (qcsi_fw_inited) {
 		qcsi_fw_inited = 0;
@@ -1664,9 +1664,9 @@ qcsi_error qcsi_deinit(void)
  * @param req_handle Handle to the request.
  * @param txn_id Pointer to store the transaction ID.
  *
- * @return qcsi_error Error code indicating the result of the operation.
+ * @return qmi_csi_error_type Error code indicating the result of the operation.
  */
-qcsi_error
+qmi_csi_error_type
 qcsi_get_txn_id
 (
 	qmi_req_handle     req_handle,

--- a/qcsi/qcsi_common.h
+++ b/qcsi/qcsi_common.h
@@ -13,7 +13,7 @@
 
 #include <stdint.h>
 #include "qmi_common.h"
-#include "qcsi.h"
+#include "qmi_csi.h"
 
 /**
  * @brief The data structure looks as follows:
@@ -236,7 +236,7 @@ typedef void *(*qcsi_open_fn_type)
  *
  * @retval QCSI_NO_ERR Success.
  */
-typedef qcsi_error (*qcsi_reg_fn_type)
+typedef qmi_csi_error_type (*qcsi_reg_fn_type)
 (
 	void *handle,
 	uint32_t service_id,
@@ -261,7 +261,7 @@ typedef qcsi_error (*qcsi_reg_fn_type)
  *
  * @retval QCSI_NO_ERR Success.
  */
-typedef qcsi_error (*qcsi_send_fn_type)
+typedef qmi_csi_error_type (*qcsi_send_fn_type)
 (
 	void *handle,
 	void *addr,
@@ -338,7 +338,7 @@ typedef struct qcsi_xport_ops_s {
  * param[in]   xport_data         Opaque data associated with the transport,
  *                               such as port ID or other parameters.
  */
-qcsi_error qcsi_init
+qmi_csi_error_type qcsi_init
 (
         qcsi_xport_ops_type     *xport_ops,
         void                    *xport_data
@@ -348,7 +348,7 @@ qcsi_error qcsi_init
  * @brief function is used to deregister a transport with the infrastructure.
  *
  */
-qcsi_error qcsi_deinit(void);
+qmi_csi_error_type qcsi_deinit(void);
 
 /**
  * @brief Signal the infrastructure that a previously busy endpoint is now
@@ -373,7 +373,7 @@ void qcsi_xport_resume_client
  *
  * @retval QCSI_NO_ERR Success.
  */
-qcsi_error qcsi_xport_connect
+qmi_csi_error_type qcsi_xport_connect
 (
 	qcsi_xport_type *xport,
 	void *addr
@@ -391,7 +391,7 @@ qcsi_error qcsi_xport_connect
  *
  * @retval QCSI_NO_ERR Success.
  */
-qcsi_error qcsi_xport_recv
+qmi_csi_error_type qcsi_xport_recv
 (
 	qcsi_xport_type *xport,
 	void *addr,
@@ -410,7 +410,7 @@ qcsi_error qcsi_xport_recv
  *
  * @retval QCSI_NO_ERR Success.
  */
-qcsi_error qcsi_xport_disconnect
+qmi_csi_error_type qcsi_xport_disconnect
 (
 	qcsi_xport_type *xport,
 	void *addr

--- a/qcsi/qcsi_xport_qrtr.c
+++ b/qcsi/qcsi_xport_qrtr.c
@@ -10,7 +10,7 @@
 #include <errno.h>
 #include <sys/time.h>
 #include "qmi_idl_lib.h"
-#include "qcsi.h"
+#include "qmi_csi.h"
 #include "qcsi_common.h"
 #include "qcsi_os.h"
 #include <linux/qrtr.h>
@@ -162,7 +162,7 @@ static void purge_tx_q
 	FREE(dest);
 }
 
-static qcsi_error  put_tx_q
+static qmi_csi_error_type  put_tx_q
 (
 	struct xport_handle *xp,
 	struct xport_qrtr_addr *addr,
@@ -173,7 +173,7 @@ static qcsi_error  put_tx_q
 {
 	struct dest_s *dest;
 	struct buf_s *buf;
-	qcsi_error rc = QCSI_NO_ERR;
+	qmi_csi_error_type rc = QCSI_NO_ERR;
 
 	dest = get_tx_q(xp, addr);
 	if(!dest) {
@@ -291,7 +291,7 @@ static void handle_resume_tx
 		qcsi_xport_resume_client(xp->xport, addr);
 }
 
-static qcsi_error init_socket
+static qmi_csi_error_type init_socket
 (
 	struct xport_handle *xp,
 	qcsi_os_params *os_params
@@ -365,7 +365,7 @@ xport_open_free_xp:
 	return NULL;
 }
 
-static qcsi_error xport_reg
+static qmi_csi_error_type xport_reg
 (
 	void *handle,
 	uint32_t service_id,
@@ -417,7 +417,7 @@ static qcsi_error xport_reg
 	return QCSI_NO_ERR;
 }
 
-static qcsi_error xport_unreg
+static qmi_csi_error_type xport_unreg
 (
 	void *handle,
 	uint32_t service_id,
@@ -430,7 +430,7 @@ static qcsi_error xport_unreg
 	return QCSI_NO_ERR;
 }
 
-static qcsi_error xport_send
+static qmi_csi_error_type xport_send
 (
 	void *handle,
 	void *addr,
@@ -444,7 +444,7 @@ static qcsi_error xport_send
 	struct sockaddr_qrtr sq;
 	struct xport_qrtr_addr *s_addr = (struct xport_qrtr_addr *)addr;
 	struct dest_s *dest;
-	qcsi_error rc;
+	qmi_csi_error_type rc;
 	ssize_t sendto_rc;
 	uint32_t max_q_len = 0;
 

--- a/tests/qcci_test.c
+++ b/tests/qcci_test.c
@@ -1,7 +1,7 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "qmi_client.h"
+#include "qmi_cci.h"
 #include "qmi_idl_lib.h"
 #include "qmi_cci_target_ext.h"
 #include <stdio.h>
@@ -149,7 +149,7 @@ void test_service_rx_cb
 	void                           *buf,
 	unsigned int                   len,
 	void                           *resp_cb_data,
-	qmi_client_error_type          transp_err
+	qmi_cci_error_type          transp_err
 )
 {
 	--pending_async;
@@ -203,19 +203,19 @@ void test_service_basic_test
 	printf("TEST: Basic Ping Test with %d ping messages.\n",num_msgs);
 	for (i=0; i<num_msgs; ++i) {
 		if (async_mode) {
-			rc = qmi_client_send_msg_async(*clnt, QMI_TEST_REQ_V01, &req, sizeof(req),
+			rc = qmi_cci_send_msg_async(*clnt, QMI_TEST_REQ_V01, &req, sizeof(req),
 						       &resp, sizeof(resp), test_service_rx_cb,
 						       (void*)&cb_data, txn);
-			printf("TEST: qmi_client_send_msg_async returned %d on loop %d\n", rc,i);
+			printf("TEST: qmi_cci_send_msg_async returned %d on loop %d\n", rc,i);
 			if (rc != 0) {
 				printf("TEST: send_msg_async error: %d\n",rc);
 				exit(1);
 			}
 			++pending_async;
 		} else {
-			rc = qmi_client_send_msg_sync(*clnt, QMI_TEST_REQ_V01, &req, sizeof(req),
+			rc = qmi_cci_send_msg_sync(*clnt, QMI_TEST_REQ_V01, &req, sizeof(req),
 							&resp, sizeof(resp), 0);
-			printf("TEST: qmi_client_send_msg_sync returned %d on loop %d\n", rc,i);
+			printf("TEST: qmi_cci_send_msg_sync returned %d on loop %d\n", rc,i);
 			if (rc != 0) {
 				printf("TEST: send_msg_sync error: %d\n",rc);
 				exit(1);
@@ -283,22 +283,22 @@ void test_service_data_test
 	       msg_size);
 	for (i=0; i<num_msgs; ++i) {
 		if (async_mode) {
-			rc = qmi_client_send_msg_async(*clnt, QMI_TEST_DATA_REQ_V01, data_req,
+			rc = qmi_cci_send_msg_async(*clnt, QMI_TEST_DATA_REQ_V01, data_req,
 						       sizeof(test_data_req_msg_v01),
 						       data_resp, sizeof(test_data_resp_msg_v01),
 						       test_service_rx_cb, (void*)&cb_data,
 						       txn);
-			printf("TEST: qmi_client_send_msg_async returned %d on loop %d\n", rc,i);
+			printf("TEST: qmi_cci_send_msg_async returned %d on loop %d\n", rc,i);
 			if (rc != 0) {
 				printf("TEST: send_msg_async error: %d\n",rc);
 				exit(1);
 			}
 			++pending_async;
 		} else {
-			rc = qmi_client_send_msg_sync(*clnt, QMI_TEST_DATA_REQ_V01, data_req,
+			rc = qmi_cci_send_msg_sync(*clnt, QMI_TEST_DATA_REQ_V01, data_req,
 						       sizeof(test_data_req_msg_v01),
 						       data_resp, sizeof(test_data_resp_msg_v01), 0);
-			printf("TEST: qmi_client_send_msg_sync returned %d on loop %d\n", rc,i);
+			printf("TEST: qmi_cci_send_msg_sync returned %d on loop %d\n", rc,i);
 			if (rc != 0) {
 				printf("TEST: send_msg_sync error: %d\n",rc);
 				exit(1);
@@ -364,23 +364,23 @@ void test_service_ind_test
 	printf("TEST: Data Indication Test with %d indications of size %d.\n",num_inds,
 	       ind_size);
 	if (async_mode) {
-		rc = qmi_client_send_msg_async(*clnt, QMI_TEST_DATA_IND_REG_REQ_V01,
+		rc = qmi_cci_send_msg_async(*clnt, QMI_TEST_DATA_IND_REG_REQ_V01,
 					       &data_ind_reg_req,
 					       sizeof(data_ind_reg_req),&data_ind_reg_resp,
 					       sizeof(data_ind_reg_resp), test_service_rx_cb,
 					       (void*)&cb_data, txn);
-		printf("TEST: qmi_client_send_msg_async returned %d\n", rc);
+		printf("TEST: qmi_cci_send_msg_async returned %d\n", rc);
 		if (rc != 0) {
 			printf("TEST: send_msg_async error: %d\n",rc);
 			exit(1);
 		}
 		++pending_async;
 	} else {
-		rc = qmi_client_send_msg_sync(*clnt, QMI_TEST_DATA_IND_REG_REQ_V01,
+		rc = qmi_cci_send_msg_sync(*clnt, QMI_TEST_DATA_IND_REG_REQ_V01,
 					       &data_ind_reg_req,
 					       sizeof(data_ind_reg_req),&data_ind_reg_resp,
 					       sizeof(data_ind_reg_resp), 0);
-		printf("TEST: qmi_client_send_msg_sync returned %d\n", rc);
+		printf("TEST: qmi_cci_send_msg_sync returned %d\n", rc);
 		if (rc != 0) {
 			printf("TEST: send_msg_sync error: %d\n",rc);
 			exit(1);
@@ -428,13 +428,13 @@ int main(int argc, char **argv)
 		printf("TEST: test_get_serivce_object failed, verify test_service_v01.h and .c match.\n");
 	}
 
-	rc = qmi_client_notifier_init(test_service_object, &os_params, &notifier);
+	rc = qmi_cci_notifier_init(test_service_object, &os_params, &notifier);
 
 	/* Check if the service is up, if not wait on a signal */
 	while(1) {
-		rc = qmi_client_get_service_list(test_service_object, NULL, NULL,
+		rc = qmi_cci_get_service_list(test_service_object, NULL, NULL,
 						 &num_services);
-		printf("TEST: qmi_client_get_service_list() returned %d num_services = %d\n",
+		printf("TEST: qmi_cci_get_service_list() returned %d num_services = %d\n",
 		       rc, num_services);
 		if(rc == QMI_NO_ERR)
 			break;
@@ -444,19 +444,19 @@ int main(int argc, char **argv)
 
 	num_entries = num_services;
 	/* The server has come up, store the information in info variable */
-	rc = qmi_client_get_service_list(test_service_object, info, &num_entries,
+	rc = qmi_cci_get_service_list(test_service_object, info, &num_entries,
 					 &num_services);
-	printf("TEST: qmi_client_get_service_list() returned %d num_entries = %d num_services = %d\n",
+	printf("TEST: qmi_cci_get_service_list() returned %d num_entries = %d num_services = %d\n",
 	       rc, num_entries, num_services);
 	if (service_connect >= num_services)
 		service_connect = 0;
 	printf("%d Test Services found: Choosing service %d(numbered starting at 0)\n",
 	       num_services, service_connect);
 
-	rc = qmi_client_init(&info[service_connect], test_service_object,
+	rc = qmi_cci_init(&info[service_connect], test_service_object,
 			     test_service_ind_cb, NULL, NULL, &clnt);
 
-	printf("TEST: qmi_client_init returned %d\n", rc);
+	printf("TEST: qmi_cci_init returned %d\n", rc);
 	switch(select_test) {
 	case TEST_SERVICE_BASIC_TEST:
 		test_service_basic_test(&clnt,&txn, iterations);
@@ -472,10 +472,10 @@ int main(int argc, char **argv)
 		usage(argv[0]);
 	}
 
-	rc = qmi_client_release(clnt);
-	printf("TEST: qmi_client_release of clnt returned %d\n", rc);
+	rc = qmi_cci_release(clnt);
+	printf("TEST: qmi_cci_release of clnt returned %d\n", rc);
 
-	rc = qmi_client_release(notifier);
-	printf("TEST: qmi_client_release of notifier returned %d\n", rc);
+	rc = qmi_cci_release(notifier);
+	printf("TEST: qmi_cci_release of notifier returned %d\n", rc);
 	return 0;
 }

--- a/tests/qcsi_test.c
+++ b/tests/qcsi_test.c
@@ -8,7 +8,7 @@
 #include <unistd.h>
 #include <getopt.h>
 #include "qmi_idl_lib.h"
-#include "qcsi.h"
+#include "qmi_csi.h"
 #include "qcsi_common.h"
 
 extern void *qmi_test_service_register_service(qcsi_os_params *os_params, uint32_t serv_instce);
@@ -83,9 +83,9 @@ void qmi_test_service_start_service(uint32_t serv_inst)
       }
     }
     os_params_in.fds = fds;
-    qcsi_handle_event(sp, &os_params_in);
+    qmi_csi_handle_event(sp, &os_params_in);
   }
-  qcsi_unregister(sp);
+  qmi_csi_unregister(sp);
   printf("Server Terminated....\n");
 }
 

--- a/tests/qcsi_test_ping.c
+++ b/tests/qcsi_test_ping.c
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include "qcsi.h"
+#include "qmi_csi.h"
 #include "test_service_v01.h"
 
 #ifdef QMI_FW_ADB_LOG
@@ -127,7 +127,7 @@ static void test_create_ind_pattern(test_data_ind_msg_v01 *IndMsg, int iIndSz)
 static void test_send_indications(ind_type *params)
 {
   int i;
-  qcsi_error resp_err;
+  qmi_csi_error_type resp_err;
   test_data_ind_reg_resp_msg_v01 resp;
   int num_inds,ind_size,ind_delay;
   /* Freed at the end of this function */
@@ -158,12 +158,12 @@ static void test_send_indications(ind_type *params)
   resp.resp.result = QMI_RESULT_SUCCESS_V01; /* QMI_RESULT_SUCCESS*/
   resp.resp.error = QMI_ERR_NONE_V01;       /* QMI_ERR_NONE */
 
-  resp_err = qcsi_send_resp(params->req_handle, params->msg_id,
+  resp_err = qmi_csi_send_resp(params->req_handle, params->msg_id,
                 &resp, sizeof(resp));
   if(resp_err != QCSI_NO_ERR)
   {
-    QMI_FW_LOGE("qcsi_send_resp returned error: %d\n", resp_err);
-	printf("qcsi_send_resp returned error: %d\n", resp_err);
+    QMI_FW_LOGE("qmi_csi_send_resp returned error: %d\n", resp_err);
+	printf("qmi_csi_send_resp returned error: %d\n", resp_err);
   }
 
   ind->data_len = ind_size;
@@ -176,12 +176,12 @@ static void test_send_indications(ind_type *params)
     // TODO: define something in the target header for sleep
     //usleep(ind_delay);
     //printf("sending indication %d of %d\n",i+1,num_inds);
-    resp_err = qcsi_send_ind(params->clnt->clnt, QMI_TEST_DATA_IND_V01, ind,
+    resp_err = qmi_csi_send_ind(params->clnt->clnt, QMI_TEST_DATA_IND_V01, ind,
                   sizeof(test_data_ind_msg_v01));
     if(resp_err != QCSI_NO_ERR)
     {
-      QMI_FW_LOGE("qcsi_send_ind returned error: %d\n",resp_err);
-	  printf("qcsi_send_ind returned error: %d\n",resp_err);
+      QMI_FW_LOGE("qmi_csi_send_ind returned error: %d\n",resp_err);
+	  printf("qmi_csi_send_ind returned error: %d\n",resp_err);
     }
   }
   printf("Indications Sent: %d\n", i);
@@ -212,7 +212,7 @@ static qcsi_cb_error test_response(client_info_type *clnt_info,
           int req_c_struct_len, void *service_cookie)
 {
   qcsi_cb_error rc = QCSI_CB_INTERNAL_ERR;
-  qcsi_error resp_err;
+  qmi_csi_error_type resp_err;
 
   /* The response message is small, and can safely be declared on the stack.
      See test_ping_data_response for a message that is large and uses
@@ -225,10 +225,10 @@ static qcsi_cb_error test_response(client_info_type *clnt_info,
      safe to send it within the callback context, and does not require dispatch
      to a new thread.  See ping_data_ind_registration to see the dispatch of
      message handling */
-  resp_err = qcsi_send_resp(req_handle, msg_id, &resp, sizeof(resp));
+  resp_err = qmi_csi_send_resp(req_handle, msg_id, &resp, sizeof(resp));
   if(resp_err != QCSI_NO_ERR)
   {
-    QMI_FW_LOGE("qcsi_send_resp returned error: %d\n",resp_err);
+    QMI_FW_LOGE("qmi_csi_send_resp returned error: %d\n",resp_err);
   }
   else
   {
@@ -263,7 +263,7 @@ static qcsi_cb_error test_data_response(client_info_type *clnt_info,
 {
   uint32_t iCount = 0;
   qcsi_cb_error rc = QCSI_CB_INTERNAL_ERR;
-  qcsi_error resp_err;
+  qmi_csi_error_type resp_err;
   service_context_type *context = (service_context_type*)service_cookie;
 
   /*Request and response messages*/
@@ -297,11 +297,11 @@ static qcsi_cb_error test_data_response(client_info_type *clnt_info,
   resp->resp.result = QMI_RESULT_SUCCESS_V01; /* QMI_RESULT_SUCCESS */
   resp->resp.error = QMI_ERR_NONE_V01;       /* QMI_ERR_NONES */
 
-  resp_err = qcsi_send_resp(req_handle, msg_id, resp,
+  resp_err = qmi_csi_send_resp(req_handle, msg_id, resp,
                 sizeof(test_data_resp_msg_v01));
   if(resp_err != QCSI_NO_ERR)
   {
-    QMI_FW_LOGE("qcsi_send_resp returned error: %d\n", resp_err);
+    QMI_FW_LOGE("qmi_csi_send_resp returned error: %d\n", resp_err);
   }
   else
   {
@@ -493,9 +493,9 @@ void *qmi_test_service_register_service(qcsi_os_params *os_params,
   uSvcOptions.instance_id = serv_instce; // TEST_APT_INSTANCE_ID
 
   qmi_idl_service_object_type test_service_object = test_get_service_object_v01();
-  qcsi_error rc = QCSI_INTERNAL_ERR;
+  qmi_csi_error_type rc = QCSI_INTERNAL_ERR;
 
-  rc = qcsi_register_with_options(test_service_object, test_connect_cb,
+  rc = qmi_csi_register_with_options(test_service_object, test_connect_cb,
           test_disconnect_cb, test_handle_req_cb, &service_cookie,
           os_params, &uSvcOptions, &service_cookie.service_handle);
 


### PR DESCRIPTION
Standardize the QMI Common Client Interface (CCI) and QMI Common Service Interface (CSI) APIs to follow consistent naming patterns and error handling approaches. This change improves code readability, maintainability, and developer experience by:

1. Renaming files to follow consistent naming patterns:
   - qmi_client.h → qmi_cci.h
   - qcsi.h → qmi_csi.h

2. Standardizing API function names with consistent prefixes:
   - Client APIs use qmi_cci_* prefix (e.g., qmi_cci_init, qmi_cci_send_msg)
   - Service APIs use qmi_csi_* prefix (e.g., qmi_csi_register, qmi_csi_send_resp)

3. Converting error code definitions from preprocessor macros to enums in the client interface for improved type safety and debugging, matching the approach already used in the service interface.